### PR TITLE
Fix: add superagent-ilp as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node-fetch": "^1.6.3",
     "streamifier": "^0.1.1",
     "superagent": "^3.5.2",
+    "superagent-ilp": "0.0.1",
     "uuid": "^3.1.0"
   }
 }


### PR DESCRIPTION
should be followed by a version bump and publish; right now installs of unhash-cli are broken with `Error: Cannot find module 'superagent-ilp'`